### PR TITLE
Set safer consistency defaults for locks/increments/compareAndSets.

### DIFF
--- a/src/org/hbase/async/HBaseClient.java
+++ b/src/org/hbase/async/HBaseClient.java
@@ -301,6 +301,7 @@ public class HBaseClient {
         new ColumnPrefixDistributedRowLock<byte[]>(keyspace, cf,
             edit.key)
             .withBackoff(new BoundedExponentialBackoff(250, 10000, 10))
+            .withConsistencyLevel(ConsistencyLevel.CL_EACH_QUORUM)
             .expireLockAfter(lock_timeout, TimeUnit.MILLISECONDS);
     try {
       num_row_locks.incrementAndGet();

--- a/src/org/hbase/async/HBaseClient.java
+++ b/src/org/hbase/async/HBaseClient.java
@@ -308,6 +308,7 @@ public class HBaseClient {
       final ColumnMap<String> columns = lock.acquireLockAndReadRow();
       final String qualifier = new String(edit.qualifier());
       final MutationBatch mutation = keyspace.prepareMutationBatch();
+      mutation.setConsistencyLevel(ConsistencyLevel.CL_EACH_QUORUM);
       mutation.withRow(cf, edit.key)
         .putColumn(qualifier, edit.value(), null);
       
@@ -362,6 +363,7 @@ public class HBaseClient {
         value = columns.get(qualifier).getLongValue() + 1;
       }
       final MutationBatch mutation = keyspace.prepareMutationBatch();
+      mutation.setConsistencyLevel(ConsistencyLevel.CL_EACH_QUORUM);
       mutation.withRow(TSDB_UID_ID_CAS, request.key)
         .putColumn(qualifier, value, null);
       lock.releaseWithMutation(mutation);


### PR DESCRIPTION
Note that `EACH_QUORUM` here could be extremely slow if you are running cassandra across multiple datacenters. But, if you are doing that, the lack of `EACH_QUORUM` here will result in broken data. Better to be slow than break your data.

As such, might be best to warn against use of opentsdb against a cassandra cluster which traverses multiple DCs.