### PR TITLE
Add configurable timeout settings

### DIFF
--- a/src/org/hbase/async/Config.java
+++ b/src/org/hbase/async/Config.java
@@ -319,6 +319,14 @@ public class Config {
     default_map.put("asynchbase.nsre.event_queue_size", "10000");
     
     /**
+     * Add configuration of timeout values to allow for the
+     * processing of huge data imports (e.g. initial migration data)
+     * without a socket timeout.
+     */
+    default_map.put("asynccassandra.socket_timeout", "10");   
+ 	default_map.put("asynccassandra.max_timeout", "10");  
+    
+    /**
      * How many different counters do we want to keep in memory for buffering.
      * Each entry requires storing the table name, row key, family name and
      * column qualifier, plus 4 small objects.

--- a/src/org/hbase/async/HBaseClient.java
+++ b/src/org/hbase/async/HBaseClient.java
@@ -132,7 +132,10 @@ public class HBaseClient {
     pool = new ConnectionPoolConfigurationImpl("MyConnectionPool")
       .setPort(config.getInt("asynccassandra.port"))
       .setMaxConnsPerHost(1)
-      .setSeeds(config.getString("asynccassandra.seeds"));
+      .setSeeds(config.getString("asynccassandra.seeds"))
+      .setSocketTimeout(config.getInt("asynccassandra.socket_timeout"))   
+      .setMaxTimeoutWhenExhausted(config.getInt("asynccassandra.max_timeout"))   
+      .setConnectTimeout(config.getInt("asynccassandra.max_timeout"));   
     monitor = new CountingConnectionPoolMonitor();
     
     tsdb_table = config.getString("tsd.storage.hbase.data_table").getBytes();


### PR DESCRIPTION
Corresponding issue :
https://github.com/OpenTSDB/asynccassandra/issues/13

Added two new configurable values with :

default_map.put("asynccassandra.socket_timeout", "10");   
default_map.put("asynccassandra.max_timeout", "10");  
